### PR TITLE
Enable Custom Objects Webhooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "install": "^0.13.0",
     "jsonwebtoken": "^8.5.1",
     "junit-xml": "^1.2.0",
-    "libxmljs": "^0.19.7",
+    "libxmljs": "^0.19.10",
     "mocha": "^8.2.1",
     "putout": "^18.1.1",
     "sinon": "^9.2.1",

--- a/src/client.js
+++ b/src/client.js
@@ -345,7 +345,6 @@ export class SalesforceClient {
 
   _validateCreateWebhookOpts({
     endpointUrl,
-    event,
     sObjectType,
     fieldsToCheck = [],
     fieldsToCheckMode = "any",
@@ -355,12 +354,6 @@ export class SalesforceClient {
     }
     if (!sObjectType) {
       throw new Error("Parameter 'sObjectType' is required.");
-    }
-    const allowedSObjectTypes = SalesforceClient.getAllowedSObjects(event);
-    if (!allowedSObjectTypes.includes(sObjectType)) {
-      throw new Error(
-        `${sObjectType} is not supported for events of type "${event}".`,
-      );
     }
     if (!Array.isArray(fieldsToCheck)) {
       throw new Error("Parameter 'fieldsToCheck' must be an array of strings.");
@@ -440,10 +433,7 @@ export class SalesforceClient {
    * `deleteWebhook`.
    */
   async createWebhookNew(opts) {
-    this._validateCreateWebhookOpts({
-      ...opts,
-      event: "new",
-    });
+    this._validateCreateWebhookOpts(opts);
 
     // Change events should be treated differently as they are special objects
     // that get triggered asynchronously whenever their associated entity is
@@ -496,10 +486,7 @@ export class SalesforceClient {
    * `deleteWebhook`.
    */
   async createWebhookUpdated(opts) {
-    this._validateCreateWebhookOpts({
-      ...opts,
-      event: "updated",
-    });
+    this._validateCreateWebhookOpts(opts);
 
     // Change events should be treated differently as they are special objects
     // that get triggered asynchronously whenever their associated entity is
@@ -564,10 +551,7 @@ export class SalesforceClient {
    * `deleteWebhook`.
    */
   async createWebhookDeleted(opts) {
-    this._validateCreateWebhookOpts({
-      ...opts,
-      event: "deleted",
-    });
+    this._validateCreateWebhookOpts(opts);
 
     // Change events should be treated differently as they are special objects
     // that get triggered asynchronously whenever their associated entity is

--- a/src/client.js
+++ b/src/client.js
@@ -345,15 +345,23 @@ export class SalesforceClient {
 
   _validateCreateWebhookOpts({
     endpointUrl,
+    event,
     sObjectType,
     fieldsToCheck = [],
     fieldsToCheckMode = "any",
+    skipValidation = false,
   }) {
     if (!endpointUrl) {
       throw new Error("Parameter 'endpointUrl' is required.");
     }
     if (!sObjectType) {
       throw new Error("Parameter 'sObjectType' is required.");
+    }
+    const allowedSObjectTypes = SalesforceClient.getAllowedSObjects(event);
+    if (!skipValidation && !allowedSObjectTypes.includes(sObjectType)) {
+      throw new Error(
+        `${sObjectType} is not supported for events of type "${event}".`,
+      );
     }
     if (!Array.isArray(fieldsToCheck)) {
       throw new Error("Parameter 'fieldsToCheck' must be an array of strings.");
@@ -433,7 +441,10 @@ export class SalesforceClient {
    * `deleteWebhook`.
    */
   async createWebhookNew(opts) {
-    this._validateCreateWebhookOpts(opts);
+    this._validateCreateWebhookOpts({
+      ...opts,
+      event: "new",
+    });
 
     // Change events should be treated differently as they are special objects
     // that get triggered asynchronously whenever their associated entity is
@@ -486,7 +497,10 @@ export class SalesforceClient {
    * `deleteWebhook`.
    */
   async createWebhookUpdated(opts) {
-    this._validateCreateWebhookOpts(opts);
+    this._validateCreateWebhookOpts({
+      ...opts,
+      event: "updated",
+    });
 
     // Change events should be treated differently as they are special objects
     // that get triggered asynchronously whenever their associated entity is
@@ -551,7 +565,10 @@ export class SalesforceClient {
    * `deleteWebhook`.
    */
   async createWebhookDeleted(opts) {
-    this._validateCreateWebhookOpts(opts);
+    this._validateCreateWebhookOpts({
+      ...opts,
+      event: "deleted",
+    });
 
     // Change events should be treated differently as they are special objects
     // that get triggered asynchronously whenever their associated entity is

--- a/yarn.lock
+++ b/yarn.lock
@@ -3820,7 +3820,7 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-libxmljs@^0.19.7:
+libxmljs@^0.19.10:
   version "0.19.10"
   resolved "https://registry.yarnpkg.com/libxmljs/-/libxmljs-0.19.10.tgz#aa169b937a3c93940c07f802a73844df30f5c4d4"
   integrity sha512-RY5/MD8Po8sGVocbODbYcdrbP6pJyA171LjFyd7Bp9wwxhmA8C5bm/VmXfpdED07fdW0FeC3lopxhG7UbwGx+g==


### PR DESCRIPTION
Removes the static SObject check so webhooks are possible for Custom Objects too.
LMK if any other special commit is needed.